### PR TITLE
Escape single '=' in a separate line for MathJax

### DIFF
--- a/B-教学案例与实践/B6-神经网络基本原理简明教程/Step2 - LinearRegression/04.4-多样本计算.md
+++ b/B-教学案例与实践/B6-神经网络基本原理简明教程/Step2 - LinearRegression/04.4-多样本计算.md
@@ -34,13 +34,13 @@ Z=
     x_2 \\ 
     x_3
 \end{pmatrix} \cdot w + b
-=
+\=
 \begin{pmatrix}
     x_1 \cdot w + b \\ 
     x_2 \cdot w + b \\ 
     x_3 \cdot w + b
 \end{pmatrix}
-=
+\=
 \begin{pmatrix}
     z_1 \\ 
     z_2 \\ 


### PR DESCRIPTION
Seems line with a single `=` terminates equation parsing, escape it makes it work for Chrome extension "MathJax for github"