### PR TITLE
Fix tag not allowed in aligned environment in Typora

### DIFF
--- a/A-基础教程/A3-神经网络高级模型（征稿）/素材积累/1.基本概率知识回顾.md
+++ b/A-基础教程/A3-神经网络高级模型（征稿）/素材积累/1.基本概率知识回顾.md
@@ -59,9 +59,9 @@ $$
 
 $$
 \begin{aligned}
-P(B) &= \sum_{i=1}^2 P(A_i) \cdot P(B|A_i) \\ \tag{3}
+P(B) &= \sum_{i=1}^2 P(A_i) \cdot P(B|A_i) \\ 
 &=0.6 \times \frac{4}{9} + 0.4 \times \frac{3}{9}=0.4
-\end{aligned}
+\end{aligned} \tag{3}
 $$
 
 可以看到，不管第一个球是什么，第二个球是黑色的概率和先验概率一致。


### PR DESCRIPTION
### Fix tag not allowed in aligned environment in Typora in `A-基础教程/A3-神经网络高级模型（征稿）/素材积累/1.基本概率知识回顾.md `

* Before:

![image](https://user-images.githubusercontent.com/43995067/99562241-cfd3d680-2a02-11eb-8b8b-9c878c256a47.png)

* After:

![image](https://user-images.githubusercontent.com/43995067/99562267-dc582f00-2a02-11eb-88b0-2a4c20ab3cdb.png)


Signed-off-by: Hollow Man <hollowman@hollowman.ml>